### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,13 +13,13 @@ SainsmartKeypad	KEYWORD1
 #######################################
 
 getKey_fastscroll	KEYWORD2
-getKey_waitrelease KEYWORD2
+getKey_waitrelease	KEYWORD2
 getKey_periodic	KEYWORD2
-getKey_instant KEYWORD2
-setAnalogReadValues KEYWORD2
-setRefreshRate KEYWORD2
+getKey_instant	KEYWORD2
+setAnalogReadValues	KEYWORD2
+setRefreshRate	KEYWORD2
 setMsToActivateFastScroll	KEYWORD2
-setFastScrollTriggerRate KEYWORD2
+setFastScrollTriggerRate	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords